### PR TITLE
Remove 2 unnecessary stubbings in VaultBuildWrapperTest.java

### DIFF
--- a/src/test/java/com/datapipe/jenkins/vault/VaultBuildWrapperTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/VaultBuildWrapperTest.java
@@ -43,7 +43,6 @@ public class VaultBuildWrapperTest {
         PrintStream logger = new PrintStream(baos);
         SimpleBuildWrapper.Context context = null;
         Run<?, ?> build = mock(Build.class);
-        when(build.getParent()).thenReturn(null);
         EnvVars envVars = mock(EnvVars.class);
         when(envVars.expand(path)).thenReturn(path);
 
@@ -75,7 +74,6 @@ public class VaultBuildWrapperTest {
     private LogicalResponse getNotFoundResponse() {
         LogicalResponse resp = mock(LogicalResponse.class);
         RestResponse rest = mock(RestResponse.class);
-        when(resp.getData()).thenReturn(new HashMap<>());
         when(resp.getRestResponse()).thenReturn(rest);
         when(rest.getStatus()).thenReturn(404);
         return resp;


### PR DESCRIPTION
In our analysis of the project, we observed that 1) the test `VaultBuildWrapperTest.testWithNonExistingPath` contains 1 unnecessary stubbing; 2) the test `VaultBuildWrapperTest.getNotFoundResponse` contains 1 unnecessary stubbing.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbing.