### PR TITLE
Remove 1 unnecessary stubbing in AbstractAuthenticatingVaultTokenCredentialTest.java

### DIFF
--- a/src/test/java/com/datapipe/jenkins/vault/credentials/SecondAbstractAuthenticatingVaultTokenCredentialTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/credentials/SecondAbstractAuthenticatingVaultTokenCredentialTest.java
@@ -17,7 +17,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-public class AbstractAuthenticatingVaultTokenCredentialTest {
+public class SecondAbstractAuthenticatingVaultTokenCredentialTest {
 
     private Vault vault;
     private Auth auth;
@@ -29,17 +29,23 @@ public class AbstractAuthenticatingVaultTokenCredentialTest {
         auth = mock(Auth.class);
         authResponse = mock(AuthResponse.class);
         when(vault.auth()).thenReturn(auth);
-        when(auth.withNameSpace(anyString())).thenReturn(auth);
         when(auth.loginByCert()).thenReturn(authResponse);
         when(authResponse.getAuthClientToken()).thenReturn("12345");
     }
 
     @Test
-    public void nonRootNamespace() {
+    public void rootNamespace() {
         ExampleVaultTokenCredential cred = new ExampleVaultTokenCredential();
-        cred.setNamespace("foo");
+        cred.setNamespace("/");
         assertEquals("12345", cred.getToken(vault));
-        verify(auth).withNameSpace("foo");
+        verify(auth).withNameSpace(null);
+    }
+
+    @Test
+    public void nullNamespace() {
+        ExampleVaultTokenCredential cred = new ExampleVaultTokenCredential();
+        assertEquals("12345", cred.getToken(vault));
+        verify(auth, never()).withNameSpace(any());
     }
 
     static class ExampleVaultTokenCredential extends AbstractAuthenticatingVaultTokenCredential {


### PR DESCRIPTION
In our analysis of the project, we observed that 
1 unnecessary stubbing which stubbed `withNameSpace` method in `setUp` is created but is never executed by 2 tests `AbstractAuthenticatingVaultTokenCredentialTest.rootNamespace`, `AbstractAuthenticatingVaultTokenCredentialTest.nullNamespace`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). We propose below a solution to remove the unnecessary stubbings.