### PR TITLE
Remove 2 unnecessary stubbings in FolderIT.java

### DIFF
--- a/src/test/java/com/datapipe/jenkins/vault/AwsHelperTest.java
+++ b/src/test/java/com/datapipe/jenkins/vault/AwsHelperTest.java
@@ -35,7 +35,7 @@ import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
 
 public class AwsHelperTest {
-
+//test test
     private static final String awsAccessKey = "ASIAIOSFODNN7EXAMPLE";
     private static final String awsSecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY";
     private static final String sessionToken = "sometoken";

--- a/src/test/java/com/datapipe/jenkins/vault/it/folder/FolderIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/folder/FolderIT.java
@@ -127,6 +127,14 @@ public class FolderIT {
         return vaultAccessor;
     }
 
+    private VaultAccessor mockVaultAccessor2() {
+        VaultAccessor vaultAccessor = mock(VaultAccessor.class);
+        LogicalResponse resp = mock(LogicalResponse.class);
+        Map<String, String> returnValue = new HashMap<>();
+        returnValue.put("key1", "some-secret");
+        return vaultAccessor;
+    }
+
     private List<VaultSecret> standardSecrets() {
         List<VaultSecret> secrets = new ArrayList<>();
         VaultSecretValue secretValue = new VaultSecretValue("envVar1", "key1");
@@ -217,7 +225,7 @@ public class FolderIT {
         List<VaultSecret> secrets = standardSecrets();
 
         VaultBuildWrapper vaultBuildWrapper = new VaultBuildWrapper(secrets);
-        VaultAccessor mockAccessor = mockVaultAccessor();
+        VaultAccessor mockAccessor = mockVaultAccessor2();
         vaultBuildWrapper.setVaultAccessor(mockAccessor);
 
         VaultConfiguration vaultConfig = new VaultConfiguration();


### PR DESCRIPTION
In our analysis of the project, we observed that 
2 unnecessary stubbings which stubbed `getData` method and `read` method in `mockVaultAccessor` are created but are never executed by the test `FolderIT.jobInFolderShouldNotBeAbleToAccessCredentialsScopedToAnotherFolder`.

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.