### PR TITLE
Removed 9 unnecessary stubbings in VaultConfigurationIT.java

### DIFF
--- a/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/VaultConfigurationIT.java
@@ -307,7 +307,7 @@ public class VaultConfigurationIT {
         List<VaultSecret> secrets = standardSecrets();
 
         VaultBuildWrapper vaultBuildWrapper = new VaultBuildWrapper(secrets);
-        VaultAccessor mockAccessor = mockVaultAccessor(GLOBAL_ENGINE_VERSION_2);
+        VaultAccessor mockAccessor = mockVaultAccessor2(GLOBAL_ENGINE_VERSION_2);
         vaultBuildWrapper.setVaultAccessor(mockAccessor);
 
         this.project.getBuildWrappersList().add(vaultBuildWrapper);
@@ -341,7 +341,7 @@ public class VaultConfigurationIT {
         List<VaultSecret> secrets = standardSecrets();
 
         VaultBuildWrapper vaultBuildWrapper = new VaultBuildWrapper(secrets);
-        VaultAccessor mockAccessor = mockVaultAccessor(GLOBAL_ENGINE_VERSION_2);
+        VaultAccessor mockAccessor = mockVaultAccessor2(GLOBAL_ENGINE_VERSION_2);
         vaultBuildWrapper.setVaultAccessor(mockAccessor);
 
         this.project.getBuildWrappersList().add(vaultBuildWrapper);
@@ -370,7 +370,7 @@ public class VaultConfigurationIT {
         List<VaultSecret> secrets = standardSecrets();
 
         VaultBuildWrapper vaultBuildWrapper = new VaultBuildWrapper(secrets);
-        VaultAccessor mockAccessor = mockVaultAccessor(GLOBAL_ENGINE_VERSION_2);
+        VaultAccessor mockAccessor = mockVaultAccessor2(GLOBAL_ENGINE_VERSION_2);
         vaultBuildWrapper.setVaultAccessor(mockAccessor);
 
         this.project.getBuildWrappersList().add(vaultBuildWrapper);
@@ -405,7 +405,7 @@ public class VaultConfigurationIT {
         List<VaultSecret> secrets = standardSecrets();
 
         VaultBuildWrapper vaultBuildWrapper = new VaultBuildWrapper(secrets);
-        VaultAccessor mockAccessor = mockVaultAccessor(GLOBAL_ENGINE_VERSION_2);
+        VaultAccessor mockAccessor = mockVaultAccessor2(GLOBAL_ENGINE_VERSION_2);
         vaultBuildWrapper.setVaultAccessor(mockAccessor);
 
         this.project.getBuildWrappersList().add(vaultBuildWrapper);
@@ -433,5 +433,27 @@ public class VaultConfigurationIT {
         when(cred.authorizeWithVault(any())).thenReturn(vault);
         return cred;
 
+    }
+
+    public static VaultAppRoleCredential createTokenCredential2(final String credentialId) {
+        Vault vault = mock(Vault.class, withSettings().serializable());
+        VaultAppRoleCredential cred = mock(VaultAppRoleCredential.class, withSettings().serializable());
+        when(cred.getId()).thenReturn(credentialId);
+        when(cred.getDescription()).thenReturn("description");
+        return cred;
+    }
+
+    public static VaultAppRoleCredential createTokenCredential3(final String credentialId) {
+        Vault vault = mock(Vault.class, withSettings().serializable());
+        VaultAppRoleCredential cred = mock(VaultAppRoleCredential.class, withSettings().serializable());
+        return cred;
+    }
+    private VaultAccessor mockVaultAccessor2(Integer engineVersion) {
+        VaultAccessor vaultAccessor = mock(VaultAccessor.class);
+        Map<String, String> returnValue = new HashMap<>();
+        returnValue.put("key1", "some-secret");
+        LogicalResponse resp = mock(LogicalResponse.class);
+        RestResponse rest = mock(RestResponse.class);
+        return vaultAccessor;
     }
 }

--- a/src/test/java/com/datapipe/jenkins/vault/it/folder/FolderIT.java
+++ b/src/test/java/com/datapipe/jenkins/vault/it/folder/FolderIT.java
@@ -49,6 +49,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static com.datapipe.jenkins.vault.it.VaultConfigurationIT.createTokenCredential2;
+import static com.datapipe.jenkins.vault.it.VaultConfigurationIT.createTokenCredential3;
 
 public class FolderIT {
     // check that you cannot access another credentials folder
@@ -87,8 +89,8 @@ public class FolderIT {
         globalConfig.setConfiguration(vaultConfig);
         globalConfig.save();
 
-        FOLDER_1_CREDENTIAL = createTokenCredential(FOLDER_1_CREDENTIALS_ID);
-        FOLDER_2_CREDENTIAL = createTokenCredential(FOLDER_2_CREDENTIALS_ID);
+        FOLDER_1_CREDENTIAL = createTokenCredential2(FOLDER_1_CREDENTIALS_ID);
+        FOLDER_2_CREDENTIAL = createTokenCredential3(FOLDER_2_CREDENTIALS_ID);
 
         FolderCredentialsProvider.FolderCredentialsProperty folder1CredProperty = new FolderCredentialsProvider.FolderCredentialsProperty(
             new DomainCredentials[]{
@@ -100,7 +102,7 @@ public class FolderIT {
                 new DomainCredentials(Domain.global(),
                     Collections.singletonList(FOLDER_2_CREDENTIAL))});
 
-        GLOBAL_CREDENTIAL_1 = createTokenCredential(GLOBAL_CREDENTIALS_ID_1);
+        GLOBAL_CREDENTIAL_1 = createTokenCredential2(GLOBAL_CREDENTIALS_ID_1);
         GLOBAL_CREDENTIAL_2 = createTokenCredential(GLOBAL_CREDENTIALS_ID_2);
 
         SystemCredentialsProvider.getInstance()


### PR DESCRIPTION
In our analysis of the project, we observed that 
1) 3 unnecessary stubbings which stubbed `getRoleId` method, `getSecretId` method, and `authorizeWithVault` method in `createTokenCredential` are created but are never executed by some method calls in `FolderIT.setupJenkins`.

2) 5 unnecessary stubbings which stubbed `getId` method,`getDescription` method,`getRoleId` method, `getSecretId` method, and `authorizeWithVault` method in `createTokenCredential` are created but are never executed by some method calls in `FolderIT.setupJenkins`. 

3) 4 unnecessary stubbings which stubbed `getData` method,`getRestResponse` method,`getStatus` method, `read` method in `mockVaultAccessor` are created but are never executed by some tests: `VaultConfigurationIT.shouldFailIfCredentialsNotConfigured`, `VaultConfigurationIT.shouldFailIfUrlNotConfigured`,`VaultConfigurationIT.shouldFailIfNoConfigurationExists`, `VaultConfigurationIT.shouldFailIfCredentialsDoNotExist`. 

Unnecessary stubbings are stubbed method calls that were never realized during test execution. Mockito recommends to remove unnecessary stubbings (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org/mockito/exceptions/misusing/UnnecessaryStubbingException.html). 

We propose below a solution to remove the unnecessary stubbings.